### PR TITLE
Improve CLI output with status line updates

### DIFF
--- a/src/crudzap.ts
+++ b/src/crudzap.ts
@@ -26,6 +26,7 @@ import { ExitError } from './error/ExitError';
 import { getLogger, setLogLevel } from './logging';
 import * as Processor from './processor';
 import { Config, ConfigSchema, DateRange } from './types';
+import { createStatus } from './util/status';
 export async function main() {
 
     // eslint-disable-next-line no-console
@@ -102,15 +103,18 @@ export async function main() {
         // --- dreadcabinet Operation ---
         const operator: DreadCabinet.Operator = await dreadcabinet.operate(config);
         const processor: Processor.Instance = await Processor.create(config, operator);
+        const status = createStatus();
 
         // TODO: Integrate dreadcabinet operator with your EML processing logic
         // Example: Iterate through files using the operator
         await operator.process(async (file: string) => {
-            //     // Your EML processing logic for 'file' here
-            logger.info(`Processing file: ${file}`);
+            status.update(`Processing file: ${file}`);
             await processor.process(file);
+            status.increment();
             return;
         }, { start: dateRange.start, end: dateRange.end });
+
+        status.summary();
 
         logger.info('Processing complete (Placeholder - dreadcabinet operator not yet used).');
         // --- End dreadcabinet Operation ---

--- a/src/util/status.ts
+++ b/src/util/status.ts
@@ -1,0 +1,28 @@
+export interface Status {
+    update(message: string): void;
+    increment(): void;
+    summary(): void;
+}
+
+export const createStatus = (): Status => {
+    let count = 0;
+    const start = process.hrtime.bigint();
+
+    const update = (message: string) => {
+        const columns = process.stdout.columns || 80;
+        const padded = message.padEnd(columns);
+        process.stdout.write(`\r${padded}`);
+    };
+
+    const increment = () => {
+        count += 1;
+    };
+
+    const summary = () => {
+        const duration = Number(process.hrtime.bigint() - start) / 1e9;
+        process.stdout.write('\n');
+        console.log(`Processed ${count} files in ${duration.toFixed(2)}s`);
+    };
+
+    return { update, increment, summary };
+};

--- a/tests/util/status.test.ts
+++ b/tests/util/status.test.ts
@@ -1,0 +1,21 @@
+import { createStatus } from '../../src/util/status';
+
+describe('status utility', () => {
+    test('update writes to stdout', () => {
+        const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true as any);
+        const status = createStatus();
+        status.update('testing');
+        expect(writeSpy).toHaveBeenCalled();
+        writeSpy.mockRestore();
+    });
+
+    test('increment and summary output', () => {
+        const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const status = createStatus();
+        status.increment();
+        status.increment();
+        status.summary();
+        expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/Processed 2 files/));
+        logSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- add `createStatus` utility for concise status updates
- integrate status tracking into main processing loop
- test status utility behavior

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails: could not download pnpm)*
- `npm run lint` *(fails: ESLint module not found)*